### PR TITLE
Migrate core functionality from shellfish to Catscript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: rootjs_2.13 rootjs_3 docs_2.13 docs_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3
+          modules-ignore: catscript-examples_2.13 catscript-examples_3 rootjs_2.13 rootjs_3 docs_2.13 docs_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ metals.sbt
 
 # npm
 node_modules/
+
+# project related
+.js
+.jvm
+.native

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,12 @@
 version = 3.8.3
-runner.dialect = scala213
+runner.dialect = scala213source3
 
 fileOverride {
   "glob:**/scala-3/**" {
     runner.dialect = scala3
   }
 }
+
+align.preset = more
+
+docstrings.style = Asterisk

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 ThisBuild / crossScalaVersions := Seq("2.13.15", "3.3.4")
 
-lazy val root = tlCrossRootProject.aggregate(catscript)
+lazy val root = tlCrossRootProject.aggregate(catscript, examples)
 
 lazy val catscript = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -40,6 +40,15 @@ lazy val catscript = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "com.disneystreaming" %% "weaver-scalacheck" % "0.8.4" % Test
     ),
     mimaPreviousArtifacts := Set()
+  )
+
+lazy val examples = project
+  .in(file("examples"))
+  .enablePlugins(NoPublishPlugin)
+  .dependsOn(catscript.jvm)
+  .settings(
+    name                 := "catscript-examples",
+    Compile / run / fork := true
   )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import laika.sbt.LaikaConfig
 import laika.config.*
 
 ThisBuild / tlBaseVersion := "0.0"
-ThisBuild / startYear := Some(2024)
-ThisBuild / licenses := Seq(License.Apache2)
-ThisBuild / tlJdkRelease := Some(11)
+ThisBuild / startYear     := Some(2024)
+ThisBuild / licenses      := Seq(License.Apache2)
+ThisBuild / tlJdkRelease  := Some(11)
 
 ThisBuild / developers := List(
   tlGitHubDev("ChristopherDavenport", "Christopher Davenport"),
@@ -12,7 +12,7 @@ ThisBuild / developers := List(
   tlGitHubDev("Hombre-x", "Gabriel Santana Paredes")
 )
 
-ThisBuild / tlSitePublishBranch := Some("main")
+ThisBuild / tlSitePublishBranch        := Some("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 
 ThisBuild / crossScalaVersions := Seq("2.13.15", "3.3.4")
@@ -25,18 +25,18 @@ lazy val catscript = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "catscript",
     libraryDependencies ++= List(
-      "org.typelevel" %% "cats-core" % "2.12.0",
+      "org.typelevel" %% "cats-core"      % "2.12.0",
       "org.typelevel" %% "alleycats-core" % "2.12.0",
-      "org.typelevel" %% "cats-effect" % "3.5.4",
-      "co.fs2" %% "fs2-core" % "3.10.2",
-      "co.fs2" %% "fs2-io" % "3.10.2",
-      "co.fs2" %% "fs2-scodec" % "3.10.2",
-      "org.scodec" %% "scodec-bits" % "1.2.0",
+      "org.typelevel" %% "cats-effect"    % "3.5.4",
+      "co.fs2"        %% "fs2-core"       % "3.10.2",
+      "co.fs2"        %% "fs2-io"         % "3.10.2",
+      "co.fs2"        %% "fs2-scodec"     % "3.10.2",
+      "org.scodec"    %% "scodec-bits"    % "1.2.0",
       "org.scodec" %% "scodec-core" % (if (scalaVersion.value.startsWith("2."))
                                          "1.11.10"
                                        else "2.3.0"),
       // Testing
-      "com.disneystreaming" %% "weaver-cats" % "0.8.4" % Test,
+      "com.disneystreaming" %% "weaver-cats"       % "0.8.4" % Test,
       "com.disneystreaming" %% "weaver-scalacheck" % "0.8.4" % Test
     ),
     mimaPreviousArtifacts := Set()

--- a/catscript/src/main/scala/org/typelevel/Catscript.scala
+++ b/catscript/src/main/scala/org/typelevel/Catscript.scala
@@ -737,6 +737,7 @@ object Catscript {
    * @return
    *   the result of the computation after using the temporary directory
    */
+  
   def withTempDirectory[A](
       dir: Option[Path],
       prefix: String,

--- a/catscript/src/main/scala/org/typelevel/Catscript.scala
+++ b/catscript/src/main/scala/org/typelevel/Catscript.scala
@@ -16,6 +16,4 @@
 
 package org.typelevel.catscript
 
-object Catscript {
-  val test = "Catscript"
-}
+

--- a/catscript/src/main/scala/org/typelevel/Catscript.scala
+++ b/catscript/src/main/scala/org/typelevel/Catscript.scala
@@ -737,7 +737,7 @@ object Catscript {
    * @return
    *   the result of the computation after using the temporary directory
    */
-  
+
   def withTempDirectory[A](
       dir: Option[Path],
       prefix: String,

--- a/catscript/src/main/scala/org/typelevel/Catscript.scala
+++ b/catscript/src/main/scala/org/typelevel/Catscript.scala
@@ -16,4 +16,730 @@
 
 package org.typelevel.catscript
 
+import cats.syntax.all.*
+import cats.effect.IO
 
+import fs2.{Stream, Chunk}
+import fs2.io.file.*
+
+import scodec.Codec
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.FiniteDuration
+
+import java.nio.charset.Charset
+
+object Catscript {
+
+  private val files: Files[IO] = Files[IO]
+
+  // Read operations:
+
+  /**
+   * Reads the contents of the file at the path using UTF-8 decoding. Returns it
+   * as a String loaded in memory.
+   *
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a String
+   */
+  def read(path: Path): IO[String] = files.readUtf8(path).compile.string
+
+  /**
+   * Reads the contents of the file at the path using the provided charset.
+   * Returns it as a String loaded in memory.
+   *
+   * @param path
+   *   The path to read from
+   * @param charset
+   *   The charset to use to decode the file
+   * @return
+   *   The file loaded in memory as a String
+   */
+  def read(path: Path, charset: Charset): IO[String] =
+    files
+      .readAll(path)
+      .through(fs2.text.decodeWithCharset(charset))
+      .compile
+      .string
+
+  /**
+   * Reads the contents of the file at the path and returns it as a ByteVector.
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a ByteVector
+   */
+  def readBytes(path: Path): IO[ByteVector] =
+    files.readAll(path).compile.to(ByteVector)
+
+  /**
+   * Reads the contents of the file at the path using UTF-8 decoding and returns
+   * it line by line as a List of Strings. It will ignore any empty characters
+   * after the last newline (similar to `wc -l`).
+   *
+   * @param path
+   *   The path to read from
+   * @return
+   *   The file loaded in memory as a collection of lines of Strings
+   */
+  def readLines(path: Path): IO[List[String]] =
+    files
+      .readUtf8Lines(path)
+      .dropLastIf(_.isEmpty)
+      .compile
+      .toList
+
+  /**
+   * Reads the contents of the file and deserializes its contents as `A` using
+   * the provided codec.
+   * @tparam A
+   *   The type to read the file as
+   * @param path
+   *   The path to read from
+   * @param Codec[A]
+   *   The codec that translates the file contents into the type `A`
+   * @return
+   *   The file loaded in memory as a type `A`
+   */
+  def readAs[A: Codec](path: Path): IO[A] =
+    readBytes(path).map(bytes => Codec[A].decodeValue(bytes.bits).require)
+
+  // Write operations:
+
+  /**
+   * This function overwrites the contents of the file at the path using UTF-8
+   * encoding with the contents provided in form of a entire string loaded in
+   * memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def write(path: Path, contents: String): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(files.writeUtf8(path))
+      .compile
+      .drain
+
+  /**
+   * This function overwrites the contents of the file at the path using the
+   * provided charset with the contents provided in form of a entire string
+   * loaded in memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param charset
+   *   The charset to use to encode the file
+   */
+  def write(
+      path: Path,
+      contents: String,
+      charset: Charset
+  ): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(fs2.text.encode(charset))
+      .through(files.writeAll(path))
+      .compile
+      .drain
+
+  /**
+   * This function overwrites the contents of the file at the path with the
+   * contents provided in form of bytes loaded in memory.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def writeBytes(path: Path, contents: ByteVector): IO[Unit] =
+    Stream
+      .chunk(Chunk.byteVector(contents))
+      .covary[IO]
+      .through(files.writeAll(path))
+      .compile
+      .drain
+
+  /**
+   * This function overwrites the contents of the file at the path using UTF-8
+   * encoding with the contents provided. Each content inside the list is
+   * written as a line in the file.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def writeLines(path: Path, contents: Seq[String]): IO[Unit] =
+    Stream
+      .emits(contents)
+      .covary[IO]
+      .through(files.writeUtf8Lines(path))
+      .compile
+      .drain
+
+  /**
+   * The functions writes the contents of the file at the path with the contents
+   * provided and returns the number of bytes written. The codec is used to
+   * translate the type A into a ByteVector so it can be parsed into the file.
+   *
+   * @tparam A
+   *   The type of the contents to write
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param Codec[A]
+   *   The codec that translates the type A into a ByteVector
+   */
+  def writeAs[A: Codec](path: Path, contents: A): IO[Unit] =
+    writeBytes(path, Codec[A].encode(contents).require.bytes)
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a String using UTF-8
+   * encoding.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def append(path: Path, contents: String): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(files.writeUtf8(path, Flags.Append))
+      .compile
+      .drain
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a String using the
+   * provided charset.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param charset
+   *   The charset to use to encode the contents
+   */
+  def append(
+      path: Path,
+      contents: String,
+      charset: Charset
+  ): IO[Unit] =
+    Stream
+      .emit(contents)
+      .covary[IO]
+      .through(fs2.text.encode(charset))
+      .through(files.writeAll(path, Flags.Append))
+      .compile
+      .drain
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a ByteVector.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def appendBytes(path: Path, contents: ByteVector): IO[Unit] =
+    Stream
+      .chunk(Chunk.byteVector(contents))
+      .covary[IO]
+      .through(files.writeAll(path, Flags.Append))
+      .compile
+      .drain
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves each line of the content at the end of the file in form of a List of
+   * Strings.
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def appendLines(path: Path, contents: Seq[String]): IO[Unit] =
+    Stream
+      .emits(contents)
+      .covary[IO]
+      .through(files.writeUtf8Lines(path, Flags.Append))
+      .compile
+      .drain
+
+  /**
+   * Similar to append, but appends a single line to the end file as a newline
+   * instead of overwriting it.
+   *
+   * Equivalent to `append(path, '\n' + contents)`
+   *
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   */
+  def appendLine(path: Path, contents: String): IO[Unit] =
+    append(path, s"\n$contents")
+
+  /**
+   * Similar to `write`, but appends to the file instead of overwriting it.
+   * Saves the content at the end of the file in form of a type `A`.
+   *
+   * @tparam A
+   *   The type of the contents to write
+   * @param path
+   *   The path to write to
+   * @param contents
+   *   The contents to write to the file
+   * @param Codec[A]
+   *   The codec that translates the type A into a ByteVector
+   */
+  def appendAs[A: Codec](path: Path, contents: A): IO[Unit] =
+    appendBytes(path, Codec[A].encode(contents).require.bytes)
+
+  // Files operations:
+
+  /**
+   * Copies the source to the target, failing if source does not exist or the
+   * target already exists. To replace the existing instead, use `copy(source,
+   * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+   */
+  def copy(source: Path, target: Path): IO[Unit] =
+    copy(source, target, CopyFlags.empty)
+
+  /**
+   * Copies the source to the target, following any directives supplied in the
+   * flags. By default, an error occurs if the target already exists, though
+   * this can be overridden via CopyFlag.ReplaceExisting.
+   */
+  def copy(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
+    files.copy(source, target, flags)
+
+  /**
+   * Creates the specified directory with the permissions of "rwxrwxr-x" by
+   * default. Fails if the parent path does not already exist.
+   */
+  def createDirectory(path: Path): IO[Unit] = files.createDirectories(path)
+
+  /**
+   * Creates the specified directory with the specified permissions. Fails if
+   * the parent path does not already exist.
+   */
+  def createDirectory(path: Path, permissions: Permissions): IO[Unit] =
+    files.createDirectories(path, permissions.some)
+
+  /**
+   * Creates the specified directory and any non-existent parent directories.
+   */
+  def createDirectories(path: Path): IO[Unit] = files.createDirectories(path)
+
+  /**
+   * Creates the specified directory and any parent directories, using the
+   * supplied permissions for any directories that get created as a result of
+   * this operation. For example if `/a` exists and
+   * `createDirectories(Path("/a/b/c"), p)` is called, `/a/b` and `/a/b/c` are
+   * created with permissions set to `p` on each (and the permissions of `/a`
+   * remain unmodified).
+   */
+  def createDirectories(path: Path, permissions: Permissions): IO[Unit] =
+    files.createDirectories(path, permissions.some)
+
+  /**
+   * Creates the specified file with the permissions of "rw-rw-r--" by default.
+   * Fails if the parent path does not already exist.
+   */
+  def createFile(path: Path): IO[Unit] = files.createFile(path)
+
+  /**
+   * Creates the specified file with the specified permissions. Fails if the
+   * parent path does not already exist.
+   */
+  def createFile(path: Path, permissions: Permissions): IO[Unit] =
+    files.createFile(path, permissions.some)
+
+  /** Creates a hard link with an existing file. */
+  def createLink(link: Path, existing: Path): IO[Unit] =
+    files.createLink(link, existing)
+
+  /** Creates a symbolic link which points to the supplied target. */
+  def createSymbolicLink(link: Path, target: Path): IO[Unit] =
+    files.createSymbolicLink(link, target)
+
+  /**
+   * Creates a symbolic link which points to the supplied target with optional
+   * permissions.
+   */
+  def createSymbolicLink(
+      link: Path,
+      target: Path,
+      permissions: Permissions
+  ): IO[Unit] =
+    files.createSymbolicLink(link, target, permissions.some)
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource, which is deleted upon
+   * resource finalization.
+   */
+  def createTempFile: IO[Path] = files.createTempFile
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource which deletes upon resource
+   * finalization.
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass none to
+   *   use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   */
+  def createTempFile(
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  ): IO[Path] = files.createTempFile(dir, prefix, suffix, permissions.some)
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   */
+  def createTempDirectory: IO[Path] = files.createTempDirectory
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass none
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created directory
+   */
+  def createTempDirectory(
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  ): IO[Path] = files.createTempDirectory(dir, prefix, permissions.some)
+
+  /** User's current working directory */
+  def currentWorkingDirectory: IO[Path] = files.currentWorkingDirectory
+
+  /**
+   * Deletes the specified file or empty directory, failing if it does not
+   * exist.
+   */
+  def delete(path: Path): IO[Unit] = files.delete(path)
+
+  /**
+   * Deletes the specified file or empty directory, passing if it does not
+   * exist.
+   */
+  def deleteIfExists(path: Path): IO[Boolean] = files.deleteIfExists(path)
+
+  /**
+   * Deletes the specified file or directory. If the path is a directory and is
+   * non-empty, its contents are recursively deleted. Symbolic links are not
+   * followed (but are deleted).
+   */
+  def deleteRecursively(
+      path: Path
+  ): IO[Unit] = deleteRecursively(path, false)
+
+  /**
+   * Deletes the specified file or directory. If the path is a directory and is
+   * non-empty, its contents are recursively deleted. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def deleteRecursively(
+      path: Path,
+      followLinks: Boolean
+  ): IO[Unit] = files.deleteRecursively(path, followLinks)
+
+  /**
+   * Returns true if the specified path exists. Symbolic links are followed --
+   * see the overload for more details on links.
+   */
+  def exists(path: Path): IO[Boolean] = exists(path, true)
+
+  /**
+   * Returns true if the specified path exists. Symbolic links are followed when
+   * `followLinks` is true. For example, if the symbolic link `foo` points to
+   * `bar` and `bar` does not exist, `exists(Path("foo"), true)` returns `false`
+   * but `exists(Path("foo"), false)` returns `true`.
+   */
+  def exists(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.exists(path, followLinks)
+
+  /**
+   * Gets `BasicFileAttributes` for the supplied path. Symbolic links are not
+   * followed.
+   */
+  def getBasicFileAttributes(path: Path): IO[BasicFileAttributes] =
+    getBasicFileAttributes(path, false)
+
+  /**
+   * Gets `BasicFileAttributes` for the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getBasicFileAttributes(
+      path: Path,
+      followLinks: Boolean
+  ): IO[BasicFileAttributes] = files.getBasicFileAttributes(path, followLinks)
+
+  /**
+   * Gets the last modified time of the supplied path. The last modified time is
+   * represented as a duration since the Unix epoch. Symbolic links are
+   * followed.
+   */
+  def getLastModifiedTime(path: Path): IO[FiniteDuration] =
+    getLastModifiedTime(path, true)
+
+  /**
+   * Gets the last modified time of the supplied path. The last modified time is
+   * represented as a duration since the Unix epoch. Symbolic links are followed
+   * when `followLinks` is true.
+   */
+  def getLastModifiedTime(
+      path: Path,
+      followLinks: Boolean
+  ): IO[FiniteDuration] = files.getLastModifiedTime(path, followLinks)
+
+  /**
+   * Gets the POSIX attributes for the supplied path. Symbolic links are not
+   * followed.
+   */
+  def getPosixFileAttributes(path: Path): IO[PosixFileAttributes] =
+    getPosixFileAttributes(path, false)
+
+  /**
+   * Gets the POSIX attributes for the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getPosixFileAttributes(
+      path: Path,
+      followLinks: Boolean
+  ): IO[PosixFileAttributes] = files.getPosixFileAttributes(path, followLinks)
+
+  /**
+   * Gets the POSIX permissions of the supplied path. Symbolic links are
+   * followed.
+   */
+  def getPosixPermissions(path: Path): IO[PosixPermissions] =
+    getPosixPermissions(path, true)
+
+  /**
+   * Gets the POSIX permissions of the supplied path. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def getPosixPermissions(
+      path: Path,
+      followLinks: Boolean
+  ): IO[PosixPermissions] = files.getPosixPermissions(path, followLinks)
+
+  /**
+   * Returns true if the supplied path exists and is a directory. Symbolic links
+   * are followed.
+   */
+  def isDirectory(path: Path): IO[Boolean] = isDirectory(path, true)
+
+  /**
+   * Returns true if the supplied path exists and is a directory. Symbolic links
+   * are followed when `followLinks` is true.
+   */
+  def isDirectory(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.isDirectory(path, followLinks)
+
+  /** Returns true if the supplied path exists and is executable. */
+  def isExecutable(path: Path): IO[Boolean] = files.isExecutable(path)
+
+  /**
+   * Returns true if the supplied path is a hidden file (note: may not check for
+   * existence).
+   */
+  def isHidden(path: Path): IO[Boolean] = files.isHidden(path)
+
+  /** Returns true if the supplied path exists and is readable. */
+  def isReadable(path: Path): IO[Boolean] = files.isReadable(path)
+
+  /**
+   * Returns true if the supplied path is a regular file. Symbolic links are
+   * followed.
+   */
+  def isRegularFile(path: Path): IO[Boolean] = isRegularFile(path, true)
+
+  /**
+   * Returns true if the supplied path is a regular file. Symbolic links are
+   * followed when `followLinks` is true.
+   */
+  def isRegularFile(path: Path, followLinks: Boolean): IO[Boolean] =
+    files.isRegularFile(path, followLinks)
+
+  /** Returns true if the supplied path is a symbolic link. */
+  def isSymbolicLink(path: Path): IO[Boolean] = files.isSymbolicLink(path)
+
+  /** Returns true if the supplied path exists and is writable. */
+  def isWritable(path: Path): IO[Boolean] = files.isWritable(path)
+
+  /** Returns true if the supplied paths reference the same file. */
+  def isSameFile(path1: Path, path2: Path): IO[Boolean] =
+    files.isSameFile(path1, path2)
+
+  /** Returns the line separator for the specific OS */
+  def lineSeparator: String = files.lineSeparator
+
+  /** Gets the contents of the specified directory. */
+  def list(path: Path): IO[List[Path]] = files.list(path).compile.toList
+
+  /**
+   * Moves the source to the target, failing if source does not exist or the
+   * target already exists. To replace the existing instead, use `move(source,
+   * target, CopyFlags(CopyFlag.ReplaceExisting))`.
+   */
+  def move(source: Path, target: Path): IO[Unit] =
+    move(source, target, CopyFlags.empty)
+
+  /**
+   * Moves the source to the target, following any directives supplied in the
+   * flags. By default, an error occurs if the target already exists, though
+   * this can be overridden via `CopyFlag.ReplaceExisting`.
+   */
+  def move(source: Path, target: Path, flags: CopyFlags): IO[Unit] =
+    files.move(source, target, flags)
+
+  /**
+   * Returns the real path i.e. the actual location of `path`. The precise
+   * definition of this method is implementation dependent but in general it
+   * derives from this path, an absolute path that locates the same file as this
+   * path, but with name elements that represent the actual name of the
+   * directories and the file.
+   */
+  def realPath(path: Path): IO[Path] = files.realPath(path)
+
+  /**
+   * Sets the last modified, last access, and creation time fields of the
+   * specified path.
+   *
+   * Times which are supplied as `None` are not modified. E.g., `setTimes(p,
+   * Some(t), Some(t), None, false)` sets the last modified and last access time
+   * to `t` and does not change the creation time.
+   *
+   * If the path is a symbolic link and `followLinks` is true, the target of the
+   * link as times set. Otherwise, the link itself has times set.
+   */
+  def setFileTimes(
+      path: Path,
+      lastModified: Option[FiniteDuration],
+      lastAccess: Option[FiniteDuration],
+      creationTime: Option[FiniteDuration],
+      followLinks: Boolean
+  ): IO[Unit] = files.setFileTimes(
+    path,
+    lastModified,
+    lastAccess,
+    creationTime,
+    followLinks
+  )
+
+  /**
+   * Sets the POSIX permissions for the supplied path. Fails on non-POSIX file
+   * systems.
+   */
+  def setPosixPermissions(path: Path, permissions: PosixPermissions): IO[Unit] =
+    files.setPosixPermissions(path, permissions)
+
+  /** Gets the size of the supplied path, failing if it does not exist. */
+  def size(path: Path): IO[Long] = files.size(path)
+
+  /**
+   * Creates a temporary file and deletes it at the end of the use of it.
+   */
+  def withTempFile[A](use: Path => IO[A]): IO[A] =
+    files.tempFile.use(use)
+
+  /**
+   * Creates a temporary file and deletes it at the end of the use of it.
+   *
+   * @tparam A
+   *   the type of the result computation
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass in None
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   The result of the computation after using the temporary file
+   */
+  def withTempFile[A](
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  )(use: Path => IO[A]): IO[A] =
+    files.tempFile(dir, prefix, suffix, permissions.some).use(use)
+
+  /**
+   * Creates a temporary directory and deletes it at the end of the use of it.
+   */
+  def withTempDirectory[A](use: Path => IO[A]): IO[A] =
+    files.tempDirectory.use(use)
+
+  /**
+   * Creates a temporary directory and deletes it at the end of the use of it.
+   *
+   * @tparam A
+   *   the type of the result computation
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass in
+   *   None to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   the result of the computation after using the temporary directory
+   */
+  def withTempDirectory[A](
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  )(use: Path => IO[A]): IO[A] =
+    files.tempDirectory(dir, prefix, permissions.some).use(use)
+
+  /** User's home directory */
+  def userHome: IO[Path] = files.userHome
+
+}

--- a/catscript/src/main/scala/org/typelevel/Catscript.scala
+++ b/catscript/src/main/scala/org/typelevel/Catscript.scala
@@ -699,6 +699,8 @@ object Catscript {
    *   the suffix string to be used in generating the file's name
    * @param permissions
    *   permissions to set on the created file
+   * @param use
+   *   function describing the computation to be done with the temporary file
    * @return
    *   The result of the computation after using the temporary file
    */
@@ -729,6 +731,9 @@ object Catscript {
    *   the prefix string to be used in generating the directory's name
    * @param permissions
    *   permissions to set on the created file
+   * @param use
+   *   function describing the computation to be done with the temporary
+   *   directory
    * @return
    *   the result of the computation after using the temporary directory
    */

--- a/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
+++ b/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
@@ -1,0 +1,656 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.catscript
+package syntax
+
+import cats.effect.IO
+
+import fs2.io.file.*
+
+import scodec.bits.ByteVector
+import scodec.Codec
+
+import scala.concurrent.duration.FiniteDuration
+import java.nio.charset.Charset
+
+package object path {
+
+  private val files = Files[IO]
+
+  implicit class FileOps(private val path: Path) extends AnyVal {
+
+    /**
+     * Reads the contents of the file at the path using UTF-8 decoding. Returns
+     * it as a String loaded in memory.
+     *
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a String
+     */
+    def read: IO[String] = Catscript.read(path)
+
+    /**
+     * Reads the contents of the file at the path using the provided charset.
+     * Returns it as a String loaded in memory.
+     *
+     * @param charset
+     *   The charset to use to decode the file
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a String
+     */
+    def read(charset: Charset): IO[String] =
+      Catscript.read(path, charset)
+
+    /**
+     * Reads the contents of the file at the path and returns it as a
+     * ByteVector.
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a ByteVector
+     */
+    def readBytes: IO[ByteVector] = Catscript.readBytes(path)
+
+    /**
+     * Reads the contents of the file at the path using UTF-8 decoding and
+     * returns it line by line as a List of Strings. It will ignore any empty
+     * characters after the last newline (similar to `wc -l`).
+     *
+     * @param path
+     *   The path to read from
+     * @return
+     *   The file loaded in memory as a collection of lines of Strings
+     */
+    def readLines: IO[List[String]] = Catscript.readLines(path)
+
+    /**
+     * Reads the contents of the file and deserializes its contents as `A` using
+     * the provided codec.
+     * @tparam A
+     *   The type to read the file as
+     * @param path
+     *   The path to read from
+     * @param Codec[A]
+     *   The codec that translates the file contents into the type `A`
+     * @return
+     *   The file loaded in memory as a type `A`
+     */
+    def readAs[A: Codec]: IO[A] = Catscript.readAs(path)
+
+    // Write operations:
+
+    /**
+     * This function overwrites the contents of the file at the path using UTF-8
+     * encoding with the contents provided in form of a entire string loaded in
+     * memory.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def write(contents: String): IO[Unit] = Catscript.write(path, contents)
+
+    /**
+     * This function overwrites the contents of the file at the path using the
+     * provided charset with the contents provided in form of a entire string
+     * loaded in memory.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param charset
+     *   The charset to use to encode the file
+     */
+    def write(contents: String, charset: Charset): IO[Unit] =
+      Catscript.write(path, contents, charset)
+
+    /**
+     * This function overwrites the contents of the file at the path with the
+     * contents provided in form of bytes loaded in memory.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def writeBytes(contents: ByteVector): IO[Unit] =
+      Catscript.writeBytes(path, contents)
+
+    /**
+     * This function overwrites the contents of the file at the path using UTF-8
+     * encoding with the contents provided. Each content inside the list is
+     * written as a line in the file.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def writeLines(contents: Seq[String]): IO[Unit] =
+      Catscript.writeLines(path, contents)
+
+    /**
+     * The functions writes the contents of the file at the path with the
+     * contents provided and returns the number of bytes written. The codec is
+     * used to translate the type A into a ByteVector so it can be parsed into
+     * the file.
+     *
+     * @tparam A
+     *   The type of the contents to write
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param Codec[A]
+     *   The codec that translates the type A into a ByteVector
+     */
+    def writeAs[A: Codec](contents: A): IO[Unit] =
+      Catscript.writeAs(path, contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves the content at the end of the file in form of a String.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def append(contents: String): IO[Unit] = Catscript.append(path, contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves the content at the end of the file in form of a String using the
+     * provided charset.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param charset
+     *   The charset to use to encode the contents
+     */
+    def append(
+        contents: String,
+        charset: Charset
+    ): IO[Unit] =
+      Catscript.append(path, contents, charset)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves the content at the end of the file in form of a ByteVector.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def appendBytes(contents: ByteVector): IO[Unit] =
+      Catscript.appendBytes(path, contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it.
+     * Saves each line of the content at the end of the file in form of a List
+     * of Strings.
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def appendLines(contents: Seq[String]): IO[Unit] =
+      Catscript.appendLines(path, contents)
+
+    /**
+     * Similar to append, but appends a single line to the end file as a newline
+     * instead of overwriting it.
+     *
+     * Equivalent to `path.append('\n' + contents)`
+     *
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     */
+    def appendLine(contents: String): IO[Unit] =
+      Catscript.appendLine(path, contents)
+
+    /**
+     * Similar to `write`, but appends to the file instead of overwriting it
+     * using the given `Codec[A]`
+     *
+     * @tparam A
+     *   The type of the contents to write
+     * @param path
+     *   The path to write to
+     * @param contents
+     *   The contents to write to the file
+     * @param Codec[A]
+     *   The codec that translates the type A into a ByteVector
+     */
+    def appendAs[A: Codec](contents: A): IO[Unit] =
+      Catscript.appendAs[A](path, contents)
+
+    // File operations:
+
+    /**
+     * Copies the source to the target, failing if source does not exist or the
+     * target already exists. To replace the existing instead, use
+     * `path.copy(target, CopyFlags(CopyFlag.ReplaceExisting))`.
+     */
+    def copy(target: Path): IO[Unit] =
+      Catscript.copy(path, target, CopyFlags.empty)
+
+    /**
+     * Copies the source to the target, following any directives supplied in the
+     * flags. By default, an error occurs if the target already exists, though
+     * this can be overridden via CopyFlag.ReplaceExisting.
+     */
+    def copy(target: Path, flags: CopyFlags): IO[Unit] =
+      Catscript.copy(path, target, flags)
+
+    /**
+     * Creates the specified directory with the permissions of "rwxrwxr-x" by
+     * default. Fails if the parent path does not already exist.
+     */
+    def createDirectory: IO[Unit] = Catscript.createDirectory(path)
+
+    /**
+     * Creates the specified directory with the specified permissions. Fails if
+     * the parent path does not already exist.
+     */
+    def createDirectory(permissions: Permissions): IO[Unit] =
+      Catscript.createDirectory(path, permissions)
+
+    /**
+     * Creates the specified directory and any non-existent parent directories.
+     */
+    def createDirectories: IO[Unit] = Catscript.createDirectories(path)
+
+    /**
+     * Creates the specified directory and any parent directories, using the
+     * supplied permissions for any directories that get created as a result of
+     * this operation.
+     */
+    def createDirectories(permissions: Permissions): IO[Unit] =
+      Catscript.createDirectories(path, permissions)
+
+    /**
+     * Creates the specified file with the permissions of "rw-rw-r--" by
+     * default. Fails if the parent path does not already exist.
+     */
+    def createFile: IO[Unit] = Catscript.createFile(path)
+
+    /**
+     * Creates the specified file with the specified permissions. Fails if the
+     * parent path does not already exist.
+     */
+    def createFile(permissions: Permissions): IO[Unit] =
+      Catscript.createFile(path, permissions)
+
+    /** Creates a hard link with an existing file. */
+    def createLink(existing: Path): IO[Unit] =
+      Catscript.createLink(path, existing)
+
+    /** Creates a symbolic link which points to the supplied target. */
+    def createSymbolicLink(target: Path): IO[Unit] =
+      Catscript.createSymbolicLink(path, target)
+
+    /**
+     * Creates a symbolic link which points to the supplied target with optional
+     * permissions.
+     */
+    def createSymbolicLink(target: Path, permissions: Permissions): IO[Unit] =
+      Catscript.createSymbolicLink(path, target, permissions)
+
+    // Deletion
+    /**
+     * Deletes the specified file or empty directory, failing if it does not
+     * exist.
+     */
+    def delete: IO[Unit] = Catscript.delete(path)
+
+    /**
+     * Deletes the specified file or empty directory, passing if it does not
+     * exist.
+     */
+    def deleteIfExists: IO[Boolean] = Catscript.deleteIfExists(path)
+
+    /**
+     * Deletes the specified file or directory. If the path is a directory and
+     * is non-empty, its contents are recursively deleted. Symbolic links are
+     * not followed (but are deleted).
+     */
+    def deleteRecursively: IO[Unit] = Catscript.deleteRecursively(path)
+
+    /**
+     * Deletes the specified file or directory. If the path is a directory and
+     * is non-empty, its contents are recursively deleted. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def deleteRecursively(followLinks: Boolean): IO[Unit] =
+      Catscript.deleteRecursively(path, followLinks)
+
+    /**
+     * Returns true if the specified path exists. Symbolic links are followed --
+     * see the overload for more details on links.
+     */
+    def exists: IO[Boolean] = Catscript.exists(path)
+
+    /**
+     * Returns true if the specified path exists. Symbolic links are followed
+     * when `followLinks` is true.
+     */
+    def exists(followLinks: Boolean): IO[Boolean] =
+      Catscript.exists(path, followLinks)
+
+    /**
+     * Gets `BasicFileAttributes` for the supplied path. Symbolic links are not
+     * followed.
+     */
+    def getBasicFileAttributes: IO[BasicFileAttributes] =
+      Catscript.getBasicFileAttributes(path)
+
+    /**
+     * Gets `BasicFileAttributes` for the supplied path. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def getBasicFileAttributes(followLinks: Boolean): IO[BasicFileAttributes] =
+      Catscript.getBasicFileAttributes(path, followLinks)
+
+    /**
+     * Gets the last modified time of the supplied path. The last modified time
+     * is represented as a duration since the Unix epoch. Symbolic links are
+     * followed.
+     */
+    def getLastModifiedTime: IO[FiniteDuration] =
+      Catscript.getLastModifiedTime(path)
+
+    /**
+     * Gets the last modified time of the supplied path. The last modified time
+     * is represented as a duration since the Unix epoch. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def getLastModifiedTime(followLinks: Boolean): IO[FiniteDuration] =
+      Catscript.getLastModifiedTime(path, followLinks)
+
+    /**
+     * Gets the POSIX attributes for the supplied path. Symbolic links are not
+     * followed.
+     */
+    def getPosixFileAttributes: IO[PosixFileAttributes] =
+      Catscript.getPosixFileAttributes(path)
+
+    /**
+     * Gets the POSIX attributes for the supplied path. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def getPosixFileAttributes(followLinks: Boolean): IO[PosixFileAttributes] =
+      Catscript.getPosixFileAttributes(path, followLinks)
+
+    /**
+     * Gets the POSIX permissions of the supplied path. Symbolic links are
+     * followed.
+     */
+    def getPosixPermissions: IO[PosixPermissions] =
+      Catscript.getPosixPermissions(path)
+
+    /**
+     * Gets the POSIX permissions of the supplied path. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def getPosixPermissions(followLinks: Boolean): IO[PosixPermissions] =
+      Catscript.getPosixPermissions(path, followLinks)
+
+    /**
+     * Returns true if the supplied path exists and is a directory. Symbolic
+     * links are followed.
+     */
+    def isDirectory: IO[Boolean] = Catscript.isDirectory(path)
+
+    /**
+     * Returns true if the supplied path exists and is a directory. Symbolic
+     * links are followed when `followLinks` is true.
+     */
+    def isDirectory(followLinks: Boolean): IO[Boolean] =
+      Catscript.isDirectory(path, followLinks)
+
+    /** Returns true if the supplied path exists and is executable. */
+    def isExecutable: IO[Boolean] = Catscript.isExecutable(path)
+
+    /**
+     * Returns true if the supplied path is a hidden file (note: may not check
+     * for existence).
+     */
+    def isHidden: IO[Boolean] = Catscript.isHidden(path)
+
+    /** Returns true if the supplied path exists and is readable. */
+    def isReadable: IO[Boolean] = Catscript.isReadable(path)
+
+    /**
+     * Returns true if the supplied path is a regular file. Symbolic links are
+     * followed.
+     */
+    def isRegularFile: IO[Boolean] = Catscript.isRegularFile(path)
+
+    /**
+     * Returns true if the supplied path is a regular file. Symbolic links are
+     * followed when `followLinks` is true.
+     */
+    def isRegularFile(followLinks: Boolean): IO[Boolean] =
+      Catscript.isRegularFile(path, followLinks)
+
+    /** Returns true if the supplied path is a symbolic link. */
+    def isSymbolicLink: IO[Boolean] = Catscript.isSymbolicLink(path)
+
+    /** Returns true if the supplied path exists and is writable. */
+    def isWritable: IO[Boolean] = Catscript.isWritable(path)
+
+    /** Returns true if the supplied path reference the same file. */
+    def isSameFile(path2: Path): IO[Boolean] = Catscript.isSameFile(path, path2)
+
+    /** Gets the contents of the specified directory. */
+    def list: IO[List[Path]] = Catscript.list(path)
+
+    /**
+     * Moves the source to the target, failing if source does not exist or the
+     * target already exists. To replace the existing instead, use
+     * `path.move(target, CopyFlags(CopyFlag.ReplaceExisting))`.
+     */
+    def move(target: Path): IO[Unit] = Catscript.move(path, target)
+
+    /**
+     * Moves the source to the target, following any directives supplied in the
+     * flags. By default, an error occurs if the target already exists, though
+     * this can be overridden via `CopyFlag.ReplaceExisting`.
+     */
+    def move(target: Path, flags: CopyFlags): IO[Unit] =
+      Catscript.move(path, target, flags)
+
+    // Real Path
+    /** Returns the real path i.e. the actual location of `path`. */
+    def realPath: IO[Path] = Catscript.realPath(path)
+
+    /**
+     * Sets the last modified, last access, and creation time fields of the
+     * specified path. Times which are supplied as `None` are not modified.
+     */
+    def setFileTimes(
+        lastModified: Option[FiniteDuration],
+        lastAccess: Option[FiniteDuration],
+        creationTime: Option[FiniteDuration],
+        followLinks: Boolean
+    ): IO[Unit] =
+      Catscript.setFileTimes(
+        path,
+        lastModified,
+        lastAccess,
+        creationTime,
+        followLinks
+      )
+
+    /**
+     * Sets the POSIX permissions for the supplied path. Fails on non-POSIX file
+     * systems.
+     */
+    def setPosixPermissions(permissions: PosixPermissions): IO[Unit] =
+      Catscript.setPosixPermissions(path, permissions)
+
+    /** Gets the size of the supplied path, failing if it does not exist. */
+    def size: IO[Long] = Catscript.size(path)
+
+  }
+
+  // No path specific methods:
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource, which is deleted upon
+   * resource finalization.
+   */
+  def createTempFile: IO[Path] = Catscript.createTempFile
+
+  /**
+   * Creates a temporary file. The created file is not automatically deleted -
+   * it is up to the operating system to decide when the file is deleted.
+   * Alternatively, use `tempFile` to get a resource which deletes upon resource
+   * finalization.
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass none to
+   *   use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   */
+  def createTempFile(
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  ): IO[Path] =
+    Catscript.createTempFile(dir, prefix, suffix, permissions)
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   */
+  def createTempDirectory: IO[Path] = Catscript.createTempDirectory
+
+  /**
+   * Creates a temporary directory. The created directory is not automatically
+   * deleted - it is up to the operating system to decide when the file is
+   * deleted. Alternatively, use `tempDirectory` to get a resource which deletes
+   * upon resource finalization.
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass none
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created directory
+   */
+  def createTempDirectory(
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  ): IO[Path] =
+    Catscript.createTempDirectory(dir, prefix, permissions)
+
+  /** User's current working directory */
+  def currentWorkingDirectory: IO[Path] = Catscript.currentWorkingDirectory
+
+  /** Returns the line separator for the specific OS */
+  def lineSeparator: String = Catscript.lineSeparator
+
+  /**
+   * Creates a temporary file and deletes it at the end of the use of it.
+   */
+  def withTempFile[A](use: Path => IO[A]): IO[A] =
+    Catscript.withTempFile(use)
+
+  /**
+   * Creates a temporary file and deletes it at the end of the use of it.
+   *
+   * @tparam A
+   *   the type of the result computation
+   *
+   * @param dir
+   *   the directory which the temporary file will be created in. Pass in None
+   *   to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the file's name
+   * @param suffix
+   *   the suffix string to be used in generating the file's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   The result of the computation after using the temporary file
+   */
+  def withTempFile[A](
+      dir: Option[Path],
+      prefix: String,
+      suffix: String,
+      permissions: Permissions
+  )(use: Path => IO[A]): IO[A] =
+    Catscript.withTempFile(dir, prefix, suffix, permissions)(use)
+
+  /**
+   * Creates a temporary directory and deletes it at the end of the use of it.
+   */
+  def withTempDirectory[A](use: Path => IO[A]): IO[A] =
+    Catscript.withTempDirectory(use)
+
+  /**
+   * Creates a temporary directory and deletes it at the end of the use of it.
+   *
+   * @tparam A
+   *   the type of the result computation
+   *
+   * @param dir
+   *   the directory which the temporary directory will be created in. Pass in
+   *   None to use the default system temp directory
+   * @param prefix
+   *   the prefix string to be used in generating the directory's name
+   * @param permissions
+   *   permissions to set on the created file
+   * @return
+   *   the result of the computation after using the temporary directory
+   */
+  def withTempDirectory[A](
+      dir: Option[Path],
+      prefix: String,
+      permissions: Permissions
+  )(use: Path => IO[A]): IO[A] =
+    Catscript.withTempDirectory(dir, prefix, permissions)(use)
+
+  /** User's home directory */
+  def userHome: IO[Path] = files.userHome
+
+}

--- a/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
+++ b/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
@@ -610,6 +610,8 @@ package object path {
    *   the suffix string to be used in generating the file's name
    * @param permissions
    *   permissions to set on the created file
+   * @param use
+   *   function describing the computation to be done with the temporary file
    * @return
    *   The result of the computation after using the temporary file
    */
@@ -640,6 +642,9 @@ package object path {
    *   the prefix string to be used in generating the directory's name
    * @param permissions
    *   permissions to set on the created file
+   * @param use
+   *   function describing the computation to be done with the temporary
+   *   directory
    * @return
    *   the result of the computation after using the temporary directory
    */

--- a/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
+++ b/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
@@ -29,7 +29,6 @@ import java.nio.charset.Charset
 
 package object path {
 
-  private val files = Files[IO]
 
   implicit class FileOps(private val path: Path) extends AnyVal {
 

--- a/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
+++ b/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
@@ -29,7 +29,6 @@ import java.nio.charset.Charset
 
 package object path {
 
-
   implicit class FileOps(private val path: Path) extends AnyVal {
 
     /**

--- a/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
+++ b/catscript/src/main/scala/org/typelevel/syntax/path/package.scala
@@ -655,6 +655,6 @@ package object path {
     Catscript.withTempDirectory(dir, prefix, permissions)(use)
 
   /** User's home directory */
-  def userHome: IO[Path] = files.userHome
+  def userHome: IO[Path] = Files[IO].userHome
 
 }

--- a/catscript/src/test/scala/org/typelevel/CatscriptSpec.scala
+++ b/catscript/src/test/scala/org/typelevel/CatscriptSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.catscript
 
 import weaver.SimpleIOSuite

--- a/catscript/src/test/scala/org/typelevel/CatscriptSpec.scala
+++ b/catscript/src/test/scala/org/typelevel/CatscriptSpec.scala
@@ -1,0 +1,342 @@
+package org.typelevel.catscript
+
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+import org.scalacheck.Gen
+
+import cats.effect.IO
+
+import fs2.io.file.*
+
+import scodec.bits.ByteVector
+import scodec.Codec
+
+import scala.concurrent.duration.*
+
+import syntax.path.*
+
+object CatscriptSpec extends SimpleIOSuite with Checkers {
+
+  test("The API should delete a file") {
+    withTempFile { path =>
+      for {
+        _       <- path.write("")
+        deleted <- path.deleteIfExists
+      } yield expect(deleted)
+    }
+  }
+
+  test("Copying a file should have the same content as the original") {
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { t1 =>
+        withTempFile { t2 =>
+          for {
+            _  <- t1.write(contents)
+            _  <- t1.copy(t2, CopyFlags(CopyFlag.ReplaceExisting))
+            s1 <- t1.read
+            s2 <- t2.read
+            _  <- t1.deleteIfExists
+            _  <- t2.deleteIfExists
+
+          } yield expect.same(s1, s2)
+        }
+      }
+    }
+  }
+
+  test(
+    "Append to a file using `appendLine` should increase the size of the file in one"
+  ) {
+
+    val contentGenerator =
+      Gen.size.flatMap(size => Gen.listOfN(size, Gen.asciiStr))
+
+    forall(contentGenerator) { contentsList =>
+      withTempFile { path =>
+        for {
+          _          <- path.writeLines(contentsList)
+          sizeBefore <- path.readLines.map(_.size)
+          _          <- path.appendLine("Im a last line!")
+          sizeAfter  <- path.readLines.map(_.size)
+        } yield expect(sizeBefore + 2 == sizeAfter)
+        // That is, one new line of the appendLine and, one newline character of the writeLines method
+      }
+    }
+  }
+
+  test("Append should behave the same as adding at the end of the string") {
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { path =>
+        for {
+          _          <- path.write(contents)
+          sizeBefore <- path.read.map(_.length)
+          _          <- path.append(contents)
+          sizeAfter  <- path.read.map(_.length)
+        } yield expect(sizeBefore + contents.length == sizeAfter)
+      }
+    }
+  }
+
+  test(
+    "`append` should behave the same as `appendLine` when prepending a newline to the contents"
+  ) {
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { t1 =>
+        withTempFile { t2 =>
+          for {
+            _     <- t1.append(s"\n$contents")
+            _     <- t2.appendLine(contents)
+            file1 <- t1.read
+            file2 <- t2.read
+          } yield expect.same(file1, file2)
+        }
+      }
+    }
+  }
+
+  test(
+    "`readAs` and `writeAs` should encode and decode correctly with the same codec"
+  ) {
+    implicit val codec: Codec[String] = scodec.codecs.ascii
+
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { path =>
+        for {
+          _          <- path.writeAs(contents)
+          sizeBefore <- path.read.map(_.length)
+          _          <- path.append(contents)
+          sizeAfter  <- path.read.map(_.length)
+        } yield expect(sizeBefore + contents.length == sizeAfter)
+      }
+    }
+  }
+
+  test("We should write bytes and read bytes") {
+
+    forall(Gen.identifier) { name =>
+      withTempFile { path =>
+        val bytes = ByteVector(name.getBytes)
+
+        for {
+          _    <- path.writeBytes(bytes)
+          file <- path.readBytes
+        } yield expect.same(bytes, file)
+      }
+    }
+  }
+
+  test(
+    "We should be able to move a file and the contents should remain the same"
+  ) {
+
+    val pathsGenerator =
+      for {
+        pathLength <- Gen.choose(1, 10)
+        names      <- Gen.listOfN(pathLength, Gen.alphaLowerStr)
+      } yield names.foldLeft(Path(""))(_ / _)
+
+    val multipleGenerators =
+      for {
+        path     <- pathsGenerator
+        contents <- Gen.asciiStr
+      } yield (path, contents)
+
+    forall(multipleGenerators) { case (path, contents) =>
+      withTempDirectory { dir =>
+        val firstPath = dir / "moving_file.data"
+        val movePath  = dir / path / "moved_file.data"
+
+        for {
+          _           <- firstPath.createFile
+          _           <- firstPath.write(contents)
+          _           <- (dir / path).createDirectories
+          _           <- firstPath.move(movePath)
+          moved       <- movePath.exists
+          file        <- movePath.read
+          oldLocation <- firstPath.exists
+        } yield expect(moved) and expect.same(contents, file) and not(
+          expect(oldLocation)
+        )
+      }
+    }
+  }
+
+  test("`size` should correctly calculate the size in bytes of a file") {
+    val contentGenerator: Gen[List[String]] =
+      Gen.size.flatMap(size => Gen.listOfN(size, Gen.asciiStr))
+
+    forall(contentGenerator) { contentsList =>
+      withTempFile { path =>
+        for {
+          _          <- path.writeLines(contentsList)
+          size       <- path.size
+          streamSize <- Files[IO].readAll(path).compile.count
+        } yield expect(size == streamSize)
+      }
+    }
+  }
+
+  test("We should create and delete recursively directories") {
+
+    val pathsGenerator =
+      for {
+        pathLength <- Gen.choose(1, 10)
+        names      <- Gen.listOfN(pathLength, Gen.alphaLowerStr)
+      } yield names.foldLeft(Path(""))(_ / _)
+
+    forall(pathsGenerator) { paths =>
+      withTempDirectory { dir =>
+        val tempDir = dir / paths
+
+        for {
+          _         <- tempDir.createDirectories
+          exists    <- tempDir.exists
+          _         <- tempDir.deleteRecursively
+          notExists <- tempDir.exists
+        } yield expect(exists) and not(expect(notExists))
+      }
+    }
+  }
+
+  test("We should be able to get and modify the last modified time of a file") {
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { path =>
+        for {
+          _      <- path.write(contents)
+          before <- path.getLastModifiedTime
+
+          _ <- path.setFileTimes(
+            lastModified = Option(before + 1.seconds),
+            None,
+            None,
+            true
+          )
+
+          after <- path.getLastModifiedTime
+          _     <- path.deleteIfExists
+        } yield expect(before < after)
+      }
+    }
+  }
+
+  test(
+    "Symbolic links should be created, and followed with the argument `followLinks`"
+  ) {
+
+    val pathsGenerator =
+      for {
+        pathLength <- Gen.choose(1, 10)
+        names      <- Gen.listOfN(pathLength, Gen.alphaLowerStr)
+      } yield names.foldLeft(Path(""))(_ / _)
+
+    forall(pathsGenerator) { path =>
+      withTempFile { file =>
+        withTempDirectory { dir =>
+          val link = dir / path / "link"
+          for {
+            _           <- (dir / path).createDirectories
+            _           <- link.createSymbolicLink(file)
+            exists      <- link.exists(followLinks = true)
+            notFollowed <- link.exists(followLinks = false)
+            _           <- link.deleteRecursively(followLinks = true)
+            notExists   <- link.exists(followLinks = true)
+          } yield expect(exists) and not(expect(notExists && notFollowed))
+        }
+      }
+    }
+  }
+
+  pureTest("A line separator should add a new line to a string") {
+    expect.same(s"$lineSeparator love live serve", s"\n love live serve")
+  }
+
+  // Warning: Platform dependent test; this may fail on some operating systems
+  test("The permissions POSIX API should approve or prevent reading") {
+    withTempFile { path =>
+      for {
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("r--r--r--").get
+        )
+        readable <- path.isReadable
+
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("---------").get
+        )
+        notReadable <- path.isReadable
+      } yield expect(readable) and not(expect(notReadable))
+    }
+  }
+
+  // Warning: Platform dependent test; this may fail on some operating systems
+  test("The permissions POSIX API should approve or prevent writing") {
+    withTempFile { path =>
+      for {
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("-w--w--w-").get
+        )
+        writable <- path.isWritable
+
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("---------").get
+        )
+        notWritable <- path.isWritable
+      } yield expect(writable) and not(expect(notWritable))
+    }
+  }
+
+  // Warning: Platform dependent test; this may fail on some operating systems
+  test("The permissions POSIX API should approve or prevent executing") {
+    withTempFile { path =>
+      for {
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("--x--x--x").get
+        )
+        executable <- path.isExecutable
+
+        _ <- path.setPosixPermissions(
+          PosixPermissions.fromString("---------").get
+        )
+        notExecutable <- path.isExecutable
+      } yield expect(executable) and not(expect(notExecutable))
+    }
+  }
+
+  // Warning: Platform-dependent test; this may fail on some operating systems
+  test("We should be able to get the file permissions in POSIX systems") {
+
+    val permissionsGenerator: Gen[PosixPermissions] =
+      for {
+        value <- Gen.choose(0, 511)
+      } yield PosixPermissions.fromInt(value).get
+
+    implicit val permShow: cats.Show[PosixPermissions] =
+      cats.Show.show(_.toString)
+
+    forall(permissionsGenerator) { permissions =>
+      withTempFile { path =>
+        for {
+          _     <- path.setPosixPermissions(permissions)
+          perms <- path.getPosixPermissions
+        } yield expect(permissions == perms)
+      }
+    }
+  }
+
+  test(
+    "Writing lines should return a list with the same length when reading them"
+  ) {
+    val contentGenerator: Gen[List[String]] =
+      Gen.size.flatMap(size => Gen.listOfN(size, Gen.alphaNumStr))
+
+    forall(contentGenerator) { contentsList =>
+      withTempFile { path =>
+        for {
+          _       <- path.writeLines(contentsList)
+          readlns <- path.readLines
+        } yield expect(contentsList.length == readlns.length)
+      }
+    }
+  }
+
+}

--- a/catscript/src/test/scala/org/typelevel/syntax/path/SyntaxSpec.scala
+++ b/catscript/src/test/scala/org/typelevel/syntax/path/SyntaxSpec.scala
@@ -1,0 +1,88 @@
+package org.typelevel.catscript
+package syntax 
+
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+import org.scalacheck.Gen
+
+import syntax.path.*
+
+object SyntaxSpec extends SimpleIOSuite with Checkers {
+
+  test(
+    "Extension methods for read, write and append should work the same as the normal ones"
+  ) {
+    forall(Gen.asciiStr) { contents =>
+      withTempFile { path =>
+        for {
+          _  <- path.write(contents)
+          _  <- path.append("Hi from the test!")
+          s1 <- path.read
+          _  <- Catscript.write(path, contents)
+          _  <- Catscript.append(path, "Hi from the test!")
+          s2 <- Catscript.read(path)
+        } yield expect.same(s1, s2)
+      }
+    }
+  }
+
+  test(
+    "Extension methods for creating and deleting a file should work the same as the normal ones"
+  ) {
+    withTempDirectory { dir =>
+      val path = dir / "sample.txt"
+      for {
+        _        <- path.createFile
+        exists   <- path.exists
+        deleted  <- path.deleteIfExists
+        _        <- Catscript.createFile(path)
+        exists2  <- Catscript.exists(path)
+        deleted2 <- Catscript.deleteIfExists(path)
+      } yield expect(exists && deleted) and expect(exists2 && deleted2)
+    }
+  }
+
+  test(
+    "Extension methods for copying a file should work the same as the normal ones"
+  ) {
+    forall(Gen.asciiStr) { contents =>
+      withTempDirectory { dir =>
+        val original = dir / "sample.txt"
+        val copy1    = dir / "sample-copy.txt"
+        val copy2    = dir / "sample-copy-jo2.txt"
+        for {
+          _  <- original.write(contents)
+          _  <- original.copy(copy1)
+          _  <- Catscript.copy(original, copy2)
+          s1 <- copy1.read
+          s2 <- copy2.read
+        } yield expect.same(s1, s2)
+      }
+    }
+  }
+
+  test(
+    "Extension methods for moving a file should work the same as the normal ones"
+  ) {
+
+    forall(Gen.asciiStr) { contents =>
+      withTempDirectory { dir =>
+        val original = dir / "sample.txt"
+        val moved    = dir / "sample-moved.txt"
+        for {
+          _      <- original.write(contents)
+          _      <- original.move(moved)
+          exists <- moved.exists
+
+          _ <- moved.delete
+
+          _       <- Catscript.write(original, contents)
+          _       <- Catscript.move(original, moved)
+          exists2 <- moved.exists
+        } yield expect(exists && exists2)
+      }
+    }
+  }
+
+}

--- a/catscript/src/test/scala/org/typelevel/syntax/path/SyntaxSpec.scala
+++ b/catscript/src/test/scala/org/typelevel/syntax/path/SyntaxSpec.scala
@@ -1,5 +1,21 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.catscript
-package syntax 
+package syntax
 
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers

--- a/examples/src/main/resources/quijote.txt
+++ b/examples/src/main/resources/quijote.txt
@@ -1,0 +1,73 @@
+El ingenioso hidalgo don Quijote de la Mancha
+
+
+TASA
+
+Yo, Juan Gallo de Andrada, escribano de Cámara del Rey nuestro señor, de
+los que residen en su Consejo, certifico y doy fe que, habiendo visto por
+los señores dél un libro intitulado El ingenioso hidalgo de la Mancha,
+compuesto por Miguel de Cervantes Saavedra, tasaron cada pliego del dicho
+libro a tres maravedís y medio; el cual tiene ochenta y tres pliegos, que
+al dicho precio monta el dicho libro docientos y noventa maravedís y medio,
+en que se ha de vender en papel; y dieron licencia para que a este precio
+se pueda vender, y mandaron que esta tasa se ponga al principio del dicho
+libro, y no se pueda vender sin ella. Y, para que dello conste, di la
+presente en Valladolid, a veinte días del mes de deciembre de mil y
+seiscientos y cuatro años.
+
+Juan Gallo de Andrada.
+
+TESTIMONIO DE LAS ERRATAS
+
+Este libro no tiene cosa digna que no corresponda a su original; en
+testimonio de lo haber correcto, di esta fee. En el Colegio de la Madre de
+Dios de los Teólogos de la Universidad de Alcalá, en primero de diciembre
+de 1604 años.
+
+El licenciado Francisco Murcia de la Llana.
+
+EL REY
+
+Por cuanto por parte de vos, Miguel de Cervantes, nos fue fecha relación
+que habíades compuesto un libro intitulado El ingenioso hidalgo de la
+Mancha, el cual os había costado mucho trabajo y era muy útil y provechoso,
+nos pedistes y suplicastes os mandásemos dar licencia y facultad para le
+poder imprimir, y previlegio por el tiempo que fuésemos servidos, o como la
+nuestra merced fuese; lo cual visto por los del nuestro Consejo, por cuanto
+en el dicho libro se hicieron las diligencias que la premática últimamente
+por nos fecha sobre la impresión de los libros dispone, fue acordado que
+debíamos mandar dar esta nuestra cédula para vos, en la dicha razón; y nos
+tuvímoslo por bien. Por la cual, por os hacer bien y merced, os damos
+licencia y facultad para que vos, o la persona que vuestro poder hubiere, y
+no otra alguna, podáis imprimir el dicho libro, intitulado El ingenioso
+hidalgo de la Mancha, que desuso se hace mención, en todos estos nuestros
+reinos de Castilla, por tiempo y espacio de diez años, que corran y se
+cuenten desde el dicho día de la data desta nuestra cédula; so pena que la
+persona o personas que, sin tener vuestro poder, lo imprimiere o vendiere,
+o hiciere imprimir o vender, por el mesmo caso pierda la impresión que
+hiciere, con los moldes y aparejos della; y más, incurra en pena de
+cincuenta mil maravedís cada vez que lo contrario hiciere. La cual dicha
+pena sea la tercia parte para la persona que lo acusare, y la otra tercia
+parte para nuestra Cámara, y la otra tercia parte para el juez que lo
+sentenciare. Con tanto que todas las veces que hubiéredes de hacer imprimir
+el dicho libro, durante el tiempo de los dichos diez años, le traigáis al
+nuestro Consejo, juntamente con el original que en él fue visto, que va
+rubricado cada plana y firmado al fin dél de Juan Gallo de Andrada, nuestro
+Escribano de Cámara, de los que en él residen, para saber si la dicha
+impresión está conforme el original; o traigáis fe en pública forma de cómo
+por corretor nombrado por nuestro mandado, se vio y corrigió la dicha
+impresión por el original, y se imprimió conforme a él, y quedan impresas
+las erratas por él apuntadas, para cada un libro de los que así fueren
+impresos, para que se tase el precio que por cada volume hubiéredes de
+haber. Y mandamos al impresor que así imprimiere el dicho libro, no imprima
+el principio ni el primer pliego dél, ni entregue más de un solo libro con
+el original al autor, o persona a cuya costa lo imprimiere, ni otro alguno,
+para efeto de la dicha correción y tasa, hasta que antes y primero el dicho
+libro esté corregido y tasado por los del nuestro Consejo; y, estando
+hecho, y no de otra manera, pueda imprimir el dicho principio y primer
+pliego, y sucesivamente ponga esta nuestra cédula y la aprobación, tasa y
+erratas, so pena de caer e incurrir en las penas contenidas en las leyes y
+premáticas destos nuestros reinos. Y mandamos a los del nuestro Consejo, y
+a otras cualesquier justicias dellos, guarden y cumplan esta nuestra cédula
+y lo en ella contenido. Fecha en Valladolid, a veinte y seis días del mes
+de setiembre de mil y seiscientos y cuatro años.

--- a/examples/src/main/resources/scores.txt
+++ b/examples/src/main/resources/scores.txt
@@ -1,0 +1,6 @@
+michel:21839
+zeta:9929
+thanh:20933
+tonio:12340
+arman:6969
+gabriel:32123

--- a/examples/src/main/scala/org/typelevel/catscript/Place.scala
+++ b/examples/src/main/scala/org/typelevel/catscript/Place.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.catscript
+
+import cats.syntax.applicative.*
+import cats.effect.{IO, IOApp}
+
+import scodec.codecs.*
+import scodec.Codec
+import fs2.io.file.Path
+
+import syntax.path.*
+
+object Place extends IOApp.Simple {
+
+  case class Place(number: Int, name: String)
+
+  implicit val placeCodec: Codec[Place] = (int32 :: utf8).as[Place]
+
+  val path = Path("src/main/resources/place.data")
+
+  def run: IO[Unit] =
+    for {
+      exists <- path.exists
+      // Equivalent of doing `if (exists) IO.unit else path.createFile`
+      _ <- path.createFile.whenA(exists)
+      _ <- path.writeAs[Place](Place(1, "Michael Phelps"))
+      _ <- path.readAs[Place].flatMap(IO.println)
+    } yield ()
+
+}

--- a/examples/src/main/scala/org/typelevel/catscript/Scores.scala
+++ b/examples/src/main/scala/org/typelevel/catscript/Scores.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.catscript
+
+import cats.syntax.all.*
+import cats.effect.{IO, IOApp}
+
+import fs2.io.file.Path
+
+import syntax.path.*
+
+object Scores extends IOApp.Simple {
+
+  case class Score(name: String, score: Int) {
+    def show: String = s"$name:$score"
+  }
+
+  def parseScore(strScore: String): Either[Throwable, Score] =
+    Either.catchNonFatal(
+      strScore.split(':') match {
+        case Array(name, score) => Score(name, score.toInt)
+        case _                  => Score("Cant parse this score", -1)
+      }
+    )
+
+  val path = Path("src/main/resources/scores.txt")
+  override def run: IO[Unit] =
+    for {
+      lines  <- path.readLines
+      scores <- lines.traverse(parseScore(_).liftTo[IO])
+      _      <- IO(scores.foreach(score => println(score.show)))
+      _      <- path.append(Score("daniela", 100).show)
+    } yield ()
+}

--- a/examples/src/main/scala/org/typelevel/catscript/Uppercase.scala
+++ b/examples/src/main/scala/org/typelevel/catscript/Uppercase.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.catscript
+
+import cats.effect.{IO, IOApp}
+import fs2.io.file.Path
+import syntax.path.*
+
+object Uppercase extends IOApp.Simple {
+
+  val path      = Path("src/main/resources/quijote.txt")
+  val upperPath = Path("src/main/resources/quijote_screaming.txt")
+
+  def run: IO[Unit] =
+    for {
+      file <- path.read
+      _    <- upperPath.write(file.toUpperCase)
+    } yield ()
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-val sbtTlVersion = "0.7.4"
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTlVersion)
-addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTlVersion)
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+val sbtTlVersion         = "0.7.4"
+addSbtPlugin("org.typelevel"    % "sbt-typelevel"      % sbtTlVersion)
+addSbtPlugin("org.typelevel"    % "sbt-typelevel-site" % sbtTlVersion)
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"        % "1.16.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"   % "0.4.17")


### PR DESCRIPTION
Solves #1 

The title says most of it, so here are some relevant changes:

The former `FilesOs` object has been renamed to `Catscript`. In the future, we need to figure out how to include the Processes API under this naming convention, or perhaps refactor it.

Changed everything else in the code related to the change above, i.e. tests and syntax.

Added previous configurations of the `.gitignore` file and the `.scalafmt` file.

Also, some of the examples are included as well. 